### PR TITLE
Development

### DIFF
--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -24,8 +24,9 @@ class InstrumentsController < ApplicationController
   def index
     # @instruments = Instrument.all.order('LOWER(name) ASC')
     # @users, @alphaParams = User.all.alpha_paginate(params[:letter]){|user| user.name}
-    @instruments, @alphaParams = Instrument.all.order('LOWER(name) ASC')
+    @instruments, @alphaParams = Instrument.all
                                      .alpha_paginate(params[:letter], {:default_field => '0-9', :include_all => false, :js => false, :bootstrap3 => true}){|instrument| instrument.name}
+    @instruments.sort_by! { |m| m.name.downcase }
   end
 
   # GET /instruments/1

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,7 +43,7 @@ module ApplicationHelper
         url_list.append(link_to('proqolid', o['url1'], target: "_blank"))
       end
       unless o['url2'].nil? || o['url2'] == ''
-        url_list.append(link_to('other', o['url2'], target: "_blank"))
+        url_list.append(link_to('ZUID (NL)', o['url2'], target: "_blank"))
       end
       unless o['url3'].nil? || o['url3'] == ''
         url_list.append(link_to('website3', o['url3'], target: "_blank"))

--- a/app/views/instruments/_form.html.erb
+++ b/app/views/instruments/_form.html.erb
@@ -59,7 +59,7 @@
 
   <div class="field row">
     <div class="col-sm-12 form-group">
-      <%= f.label :url2 %>
+      <%= f.label 'ZUYD (NL)' %>
       <%= f.text_field :url2, :class => "form-control" %>
     </div>
   </div>

--- a/app/views/instruments/index.html.erb
+++ b/app/views/instruments/index.html.erb
@@ -14,7 +14,7 @@
   <th>pmid</th>
   <th>refurl</th>
   <th>PROQOLID</th>
-  <th>Url2</th>
+  <th>ZUYD (NL)</th>
   <th>Url3</th>
   <th>#records</th>
   <th colspan="8"></th>

--- a/app/views/instruments/show.html.erb
+++ b/app/views/instruments/show.html.erb
@@ -11,7 +11,7 @@
 </p>
 
 <p>
-  <strong>Url2:</strong>
+  <strong>ZUID (NL):</strong>
   <%= @instrument.url2 %>
 </p>
 


### PR DESCRIPTION
mail 21-1-2019

.

-	de alfabetisering was ingesteld op hoofdletter ongevoelig en dat is nu weer weg. Kan dat weer terug
gezet worden?
-	Met ctrl F kon ik zoeken in de lijst met meetinstrumenten, maar dat werkt niet meer goed. 
-	De link naar de NLse database (vanuit de instrumenten lijst) heeft nu de naam ‘URL2’,  zou je die kunnen veranderen in ‘ZUYD (NL)’?

